### PR TITLE
feat:dockerfile 추가

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+
+WORKDIR /app
+
+# 의존성 파일 복사
+COPY pyproject.toml uv.lock ./
+
+# 의존성 설치
+RUN uv sync --frozen --no-dev
+
+# 소스 코드 복사
+COPY . .
+
+# 포트 노출
+EXPOSE 8000
+
+# 실행
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
### 📝 **변경 사항 요약**
WorkInKorea 서버를 Docker 컨테이너로 배포할 수 있도록 Dockerfile을 추가하고, uv 패키지 매니저를 활용한 효율적인 컨테이너 이미지 구성을 구현했습니다.

### 🔧 **주요 변경 내용**

#### **Docker 컨테이너화**
- **Dockerfile 추가** (`dockerfile`)
  ```dockerfile
  FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
  
  WORKDIR /app
  
  # 의존성 파일 복사
  COPY pyproject.toml uv.lock ./
  
  # 의존성 설치
  RUN uv sync --frozen --no-dev
  
  # 소스 코드 복사
  COPY . .
  
  # 포트 노출
  EXPOSE 8000
  
  # 실행
  CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
  ```