### PR TITLE
fix: 구글 로그인  callback url변경 및 미사용 엔드포인트 삭제

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -22,26 +22,6 @@ router = APIRouter(
 
 
 @router.get("/login/google")
-async def login_google():
-    """
-    google login
-    """
-    try:
-        params = {
-            "client_id": SETTINGS.GOOGLE_CLIENT_ID,
-            "redirect_uri": SETTINGS.GOOGLE_REDIRECT_URI,
-            "response_type": "code",
-            "scope": "email profile",
-            "access_type": "offline",
-            "prompt": "consent",
-        }
-        url = f"{SETTINGS.GOOGLE_AUTHORIZATION_URL}?{urlencode(params)}"
-        return {"url": url}
-    except Exception as e:
-        return {"error": str(e)}
-
-
-@router.get("/login/google/test")
 async def login_google_test():
     """
     google login test
@@ -128,7 +108,7 @@ async def login_google_callback(code: str, db: AsyncSession = Depends(get_async_
             return RedirectResponse(url=url)
 
         # jwt token 쿠키에 저장
-        success_url = f"{SETTINGS.CLIENT_URL}?{urlencode(status_massage_dict)}"
+        success_url = f"{SETTINGS.CLIENT_URL}/auth/callback?{urlencode(status_massage_dict)}"
         response = RedirectResponse(url=success_url)
         response.set_cookie(
             key="access_token",


### PR DESCRIPTION
## 변경사항 요약
 callback url에서 변경및 사용하지 않는 엔드포인트 삭제

## 주요 변경 기능

### Google OAuth 2.0 로그인 플로우
- **callback url 수정**: `/api/auth/login/google/callback` - Google성공시 callback url 변경
- **엔드포인트 삭제**: `/api/auth/login/google/` - 사용하지 않는 엔드포인트 삭제

## 변경된 파일들
- `app/auth/router.py` 



