### PR TITLE
Fix : GMAIL_SERVICE_ACCOUNT_JSON을 env.yaml에서 분리하여 --set-env-vars로 전달

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -88,7 +88,6 @@ jobs:
           ACCESS_TOKEN_EXPIRE_MINUTES: "${{ secrets.ACCESS_TOKEN_EXPIRE_MINUTES }}"
           REFRESH_TOKEN_EXPIRE_MINUTES: "${{ secrets.REFRESH_TOKEN_EXPIRE_MINUTES }}"
           GMAIL_FROM: "${{ secrets.GMAIL_FROM }}"
-          GMAIL_SERVICE_ACCOUNT_JSON: "${{ secrets.GMAIL_SERVICE_ACCOUNT_JSON }}"
           GMAIL_DELEGATED_USER: "${{ secrets.GMAIL_DELEGATED_USER }}"
           MINIO_ENDPOINT: "${{ secrets.MINIO_ENDPOINT }}"
           MINIO_ACCESS_KEY: "${{ secrets.MINIO_ACCESS_KEY }}"
@@ -113,7 +112,8 @@ jobs:
             --ingress internal-and-cloud-load-balancing \
             --allow-unauthenticated \
             --port 8000 \
-            --env-vars-file env.yaml
+            --env-vars-file env.yaml \
+            --set-env-vars "GMAIL_SERVICE_ACCOUNT_JSON=${{ secrets.GMAIL_SERVICE_ACCOUNT_JSON }}"
 
       - name: Send Discord Deployment Notification
         if: always()

--- a/.github/workflows/deploy-pro.yml
+++ b/.github/workflows/deploy-pro.yml
@@ -91,7 +91,6 @@ jobs:
           ACCESS_TOKEN_EXPIRE_MINUTES: "${{ secrets.ACCESS_TOKEN_EXPIRE_MINUTES }}"
           REFRESH_TOKEN_EXPIRE_MINUTES: "${{ secrets.REFRESH_TOKEN_EXPIRE_MINUTES }}"
           GMAIL_FROM: "${{ secrets.GMAIL_FROM }}"
-          GMAIL_SERVICE_ACCOUNT_JSON: "${{ secrets.GMAIL_SERVICE_ACCOUNT_JSON }}"
           GMAIL_DELEGATED_USER: "${{ secrets.GMAIL_DELEGATED_USER }}"
           MINIO_ENDPOINT: "${{ secrets.MINIO_ENDPOINT }}"
           MINIO_ACCESS_KEY: "${{ secrets.MINIO_ACCESS_KEY }}"
@@ -115,7 +114,8 @@ jobs:
             --ingress internal-and-cloud-load-balancing \
             --allow-unauthenticated \
             --port 8000 \
-            --env-vars-file env.yaml
+            --env-vars-file env.yaml \
+            --set-env-vars "GMAIL_SERVICE_ACCOUNT_JSON=${{ secrets.GMAIL_SERVICE_ACCOUNT_JSON }}"
 
       - name: Send Discord Deployment Notification
         if: always()


### PR DESCRIPTION
## 요약
  - `GMAIL_SERVICE_ACCOUNT_JSON`은 JSON 특수문자로 인한 YAML 파싱 오류 방지를 위해 
  `--set-env-vars`로 별도 전달 