### PR TITLE
Fix : 외래키 CASCADE 추가 및 signup message 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ alembic/env.py 파일에 모델 추가
 from app.auth.models import *
 ```
 
+### Alembic 수동 마이그레이션 생성                                               
+  1. `uv run alembic revision -m "Creat your message"` — DB 접속 없이 빈          
+  마이그레이션 파일 생성                                                           
+  2. 생성된 파일(`alembic/versions/`)의 `upgrade()`/`downgrade()` 함수에 직접 SQL 작성                                                                             
+  3. 배포 시 `uv run alembic upgrade head`로 적용    
+
 ```bash
 # 마이그레이션 생성
 uv run alembic revision --autogenerate -m "Creat your message"

--- a/alembic/versions/74bb0a42d89e_fix_add_ondelete_cascade_to_fkeys.py
+++ b/alembic/versions/74bb0a42d89e_fix_add_ondelete_cascade_to_fkeys.py
@@ -1,0 +1,71 @@
+"""fix: add ondelete CASCADE to foreign keys
+
+Revision ID: 74bb0a42d89e
+Revises: f6379ed575e3
+Create Date: 2026-04-11
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '74bb0a42d89e'
+down_revision: Union[str, None] = 'f6379ed575e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # resumes.user_id -> CASCADE
+    op.drop_constraint('resumes_user_id_fkey', 'resumes', type_='foreignkey')
+    op.create_foreign_key('resumes_user_id_fkey', 'resumes', 'users', ['user_id'], ['id'], ondelete='CASCADE')
+
+    # schools.resume_id -> CASCADE
+    op.drop_constraint('schools_resume_id_fkey', 'schools', type_='foreignkey')
+    op.create_foreign_key('schools_resume_id_fkey', 'schools', 'resumes', ['resume_id'], ['id'], ondelete='CASCADE')
+
+    # career_history.resume_id -> CASCADE
+    op.drop_constraint('career_history_resume_id_fkey', 'career_history', type_='foreignkey')
+    op.create_foreign_key('career_history_resume_id_fkey', 'career_history', 'resumes', ['resume_id'], ['id'], ondelete='CASCADE')
+
+    # licenses.resume_id -> CASCADE
+    op.drop_constraint('licenses_resume_id_fkey', 'licenses', type_='foreignkey')
+    op.create_foreign_key('licenses_resume_id_fkey', 'licenses', 'resumes', ['resume_id'], ['id'], ondelete='CASCADE')
+
+    # introductions.resume_id -> CASCADE
+    op.drop_constraint('introductions_resume_id_fkey', 'introductions', type_='foreignkey')
+    op.create_foreign_key('introductions_resume_id_fkey', 'introductions', 'resumes', ['resume_id'], ['id'], ondelete='CASCADE')
+
+    # language_skills.resume_id -> CASCADE
+    op.drop_constraint('language_skills_resume_id_fkey', 'language_skills', type_='foreignkey')
+    op.create_foreign_key('language_skills_resume_id_fkey', 'language_skills', 'resumes', ['resume_id'], ['id'], ondelete='CASCADE')
+
+    # notices.author_id -> SET NULL
+    op.drop_constraint('notices_author_id_fkey', 'notices', type_='foreignkey')
+    op.create_foreign_key('notices_author_id_fkey', 'notices', 'users', ['author_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade() -> None:
+    # revert all to no ondelete action
+    op.drop_constraint('resumes_user_id_fkey', 'resumes', type_='foreignkey')
+    op.create_foreign_key('resumes_user_id_fkey', 'resumes', 'users', ['user_id'], ['id'])
+
+    op.drop_constraint('schools_resume_id_fkey', 'schools', type_='foreignkey')
+    op.create_foreign_key('schools_resume_id_fkey', 'schools', 'resumes', ['resume_id'], ['id'])
+
+    op.drop_constraint('career_history_resume_id_fkey', 'career_history', type_='foreignkey')
+    op.create_foreign_key('career_history_resume_id_fkey', 'career_history', 'resumes', ['resume_id'], ['id'])
+
+    op.drop_constraint('licenses_resume_id_fkey', 'licenses', type_='foreignkey')
+    op.create_foreign_key('licenses_resume_id_fkey', 'licenses', 'resumes', ['resume_id'], ['id'])
+
+    op.drop_constraint('introductions_resume_id_fkey', 'introductions', type_='foreignkey')
+    op.create_foreign_key('introductions_resume_id_fkey', 'introductions', 'resumes', ['resume_id'], ['id'])
+
+    op.drop_constraint('language_skills_resume_id_fkey', 'language_skills', type_='foreignkey')
+    op.create_foreign_key('language_skills_resume_id_fkey', 'language_skills', 'resumes', ['resume_id'], ['id'])
+
+    op.drop_constraint('notices_author_id_fkey', 'notices', type_='foreignkey')
+    op.create_foreign_key('notices_author_id_fkey', 'notices', 'users', ['author_id'], ['id'])

--- a/app/admin/models/notice.py
+++ b/app/admin/models/notice.py
@@ -14,5 +14,5 @@ class Notice(Base):
     content: Mapped[str] = mapped_column(Text)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True) # 공지 활성화/비활성화 -> 가려놓기 기능
     
-    author_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=True) # 작성한 담당자
+    author_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True) # 작성한 담당자
     author: Mapped["User"] = relationship("User")

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -117,8 +117,8 @@ async def login_google_callback(
         if not user:
             # user 조회 실패
             status_massage = urlencode({
-                "status": "error",
-                "message": "User not found"
+                "user_email": user_info_data['email'],
+                "status": "error"
             })
             url = f"{SETTINGS.CLIENT_URL}/signup?{status_massage}"
             return RedirectResponse(url=url)

--- a/app/posts/models/career_history.py
+++ b/app/posts/models/career_history.py
@@ -7,7 +7,7 @@ from sqlalchemy import Date, Boolean, Text
 class CareerHistory(Base):
     __tablename__ = "career_history"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id"), index=True)
+    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id", ondelete="CASCADE"), index=True)
     company_name: Mapped[str] = mapped_column(String, index=True)
     start_date: Mapped[datetime] = mapped_column(Date, index=True)
     end_date: Mapped[datetime] = mapped_column(Date, index=True, nullable=True)

--- a/app/posts/models/introduction.py
+++ b/app/posts/models/introduction.py
@@ -6,7 +6,7 @@ from sqlalchemy import Text
 class Introduction(Base):
     __tablename__ = "introduction"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id"), index=True)
+    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id", ondelete="CASCADE"), index=True)
     title: Mapped[str] = mapped_column(String, index=True)
     content: Mapped[str] = mapped_column(Text, index=True, nullable=True)
 

--- a/app/posts/models/language_skill.py
+++ b/app/posts/models/language_skill.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 class LanguageSkills(Base):
     __tablename__ = "language_skills"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id"), index=True)
+    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id", ondelete="CASCADE"), index=True)
     language_type: Mapped[str] = mapped_column(String, index=True, nullable=True)
     level: Mapped[str] = mapped_column(String, index=True, nullable=True)
 

--- a/app/posts/models/license.py
+++ b/app/posts/models/license.py
@@ -7,7 +7,7 @@ from sqlalchemy import Date
 class Licenses(Base):
     __tablename__ = "licenses"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id"), index=True)
+    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id", ondelete="CASCADE"), index=True)
     license_name: Mapped[str] = mapped_column(String, index=True, nullable=True)
     license_agency: Mapped[str] = mapped_column(String, index=True, nullable=True)
     license_date: Mapped[datetime] = mapped_column(Date, index=True, nullable=True)

--- a/app/posts/models/resume.py
+++ b/app/posts/models/resume.py
@@ -7,7 +7,7 @@ from datetime import datetime
 class Resume(Base):
     __tablename__ = "resumes"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True)
     title: Mapped[str] = mapped_column(String, index=True)
     profile_url: Mapped[str] = mapped_column(String, index=True, nullable=True)
     resume_url: Mapped[str] = mapped_column(String, index=True, nullable=True)

--- a/app/posts/models/school.py
+++ b/app/posts/models/school.py
@@ -7,7 +7,7 @@ from sqlalchemy import Date, Boolean
 class Schools(Base):
     __tablename__ = "schools"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id"), index=True)
+    resume_id: Mapped[int] = mapped_column(Integer, ForeignKey("resumes.id", ondelete="CASCADE"), index=True)
     school_name: Mapped[str] = mapped_column(String, index=True)
     major_name: Mapped[str] = mapped_column(String, index=True)
     start_date: Mapped[datetime] = mapped_column(Date, index=True)


### PR DESCRIPTION
### 요약                                                                         
  - users 삭제 시 연관 데이터가 함께 삭제되지 않는 문제 수정
  - Google 로그인 시 미등록 사용자 리다이렉트에 이메일 파라미터 추가               
                                                                                   
  ### 주요 변경 사항                                                               
                                                                                   
  #### 1. 외래키 CASCADE 추가                                                      
  users 삭제 시 `resumes` 테이블의 외래키 제약조건 위반으로 삭제가 불가능한 문제를 
  수정                                                                             
                                                                                   
  | 테이블 | FK | ondelete |                                                       
  |--------|-----|----------|                                                      
  | `resumes` → `users` | `user_id` | CASCADE (추가) |                             
  | `schools` → `resumes` | `resume_id` | CASCADE (추가) |                         
  | `career_history` → `resumes` | `resume_id` | CASCADE (추가) |                  
  | `licenses` → `resumes` | `resume_id` | CASCADE (추가) |                        
  | `introductions` → `resumes` | `resume_id` | CASCADE (추가) |                   
  | `language_skills` → `resumes` | `resume_id` | CASCADE (추가) |                 
  | `notices` → `users` | `author_id` | SET NULL (추가) |                          
                                                                                   
  #### 2. signup 리다이렉트 개선
  Google 로그인 시 미등록 사용자를 signup 페이지로 리다이렉트할 때 `user_email`    
  파라미터 추가                                                                    
  - 변경 전: `/signup?status=error&message=User+not+found`
  - 변경 후: `/signup?user_email=user%40gmail.com&status=error`                    
                                                                                   
  ### 변경 파일                                                                    
                                                                                   
  | 파일 | 내용 |                                                               
  |------|------|
  | `app/posts/models/resume.py` | `ondelete="CASCADE"` 추가 |                     
  | `app/posts/models/school.py` | `ondelete="CASCADE"` 추가 |
  | `app/posts/models/career_history.py` | `ondelete="CASCADE"` 추가 |             
  | `app/posts/models/license.py` | `ondelete="CASCADE"` 추가 |                 
  | `app/posts/models/introduction.py` | `ondelete="CASCADE"` 추가 |               
  | `app/posts/models/language_skill.py` | `ondelete="CASCADE"` 추가 |          
  | `app/admin/models/notice.py` | `ondelete="SET NULL"` 추가 |                    
  | `app/auth/router.py` | 리다이렉트 URL에 `user_email` 파라미터 추가 |           
  | `alembic/versions/74bb0a42d89e_...py` | 외래키 제약조건 마이그레이션 |         
  | `README.md` | 수동 마이그레이션 생성 방법 추가 |           